### PR TITLE
Añadir plantilla de CloudFormation para crear un secreto en AWS Secre…

### DIFF
--- a/40SecretManager/40AWS_Secret_Manager.yaml
+++ b/40SecretManager/40AWS_Secret_Manager.yaml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'CloudFormation template para crear un secreto en AWS Secrets Manager con credenciales de base de datos para una aplicación Flask.
+  Este template define un recurso de Secrets Manager que almacena las credenciales necesarias para conectarse a una base de datos RDS. 
+  El secreto incluye el host, usuario, contraseña y nombre de la base de datos. 
+  El usuario y la contraseña se pasan como parámetros al momento de desplegar la plantilla, lo que permite mantener las credenciales seguras y no hardcodeadas en el código.
+  Además, se exportan el ARN y el nombre del secreto para su uso en otras partes de la infraestructura desplegada.'
+
+Parameters:
+  DBUser:
+    Type: String
+    Description: Usuario de la base de datos
+    Default: tu_usuario
+    MinLength: 1
+    MaxLength: 41
+  
+  DBPassword:
+    Type: String
+    Description: Password de la base de datos
+    NoEcho: true
+    MinLength: 8
+
+Resources:
+  # Recurso de Secrets Manager para almacenar credenciales de base de datos
+  DatabaseSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: secretos-despliegue-aws
+      Description: Database credentials for Flask app
+      SecretString: !Sub |
+        {
+          "DB_HOST": "tu-rds-endpoint.amazonaws.com",
+          "DB_USER": "${DBUser}",
+          "DB_PASSWORD": "${DBPassword}",
+          "DB_NAME": "AlumnosClases"
+        }
+
+Outputs:
+  SecretArn:
+    Description: ARN del secreto creado
+    Value: !GetAtt DatabaseSecret.Id
+    Export:
+      Name: !Sub '${AWS::StackName}-SecretArn'
+  
+  SecretName:
+    Description: Nombre del secreto
+    Value: !Ref DatabaseSecret
+    Export:
+      Name: !Sub '${AWS::StackName}-SecretName'


### PR DESCRIPTION
Añadir plantilla de CloudFormation para crear un secreto en AWS Secrets Manager: incluir parámetros para credenciales de base de datos y exportar ARN y nombre del secreto.
